### PR TITLE
Update clock frequency for Pico 2

### DIFF
--- a/examples/loopback/w6x00_loopback.c
+++ b/examples/loopback/w6x00_loopback.c
@@ -26,7 +26,8 @@
  * ----------------------------------------------------------------------------------------------------
  */
 /* Clock */
-#define PLL_SYS_KHZ (133 * 1000)
+// #define PLL_SYS_KHZ (133 * 1000) // for Pico 1
+#define PLL_SYS_KHZ (150 * 1000) // for Pico 2
 
 /* Buffer */
 #define ETHERNET_BUF_MAX_SIZE (1024 * 2)


### PR DESCRIPTION
Pico 2 should run at 150MHz unless there is a good reason not to.  Potentially this should depend on top-level CMake config.